### PR TITLE
Set method lenght to 15 lines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,6 @@ Style/Documentation:
 Naming/FileName:
   Exclude:
     - 'lib/electionbuddy-ruby.rb'
+
+Metrics/MethodLength:
+  Max: 15


### PR DESCRIPTION
Updated rubocop.yml to set Metrics/MethodLength maximum length to 15 lines.