### PR TITLE
Add faraday and debug dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "rake", "~> 13.0"
 gem "minitest", "~> 5.16"
 
 gem "rubocop", "~> 1.21"
+
+gem "debug", "~> 1.9", ">= 1.9.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,22 +2,45 @@ PATH
   remote: .
   specs:
     electionbuddy-ruby (0.1.0)
+      faraday (~> 2.12)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    faraday (2.12.0)
+      faraday-net_http (>= 2.0, < 3.4)
+      json
+      logger
+    faraday-net_http (3.3.0)
+      net-http
+    io-console (0.7.2)
+    irb (1.14.1)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.7.4)
     language_server-protocol (3.17.0.3)
+    logger (1.6.1)
     minitest (5.25.1)
+    net-http (0.4.1)
+      uri
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
+    psych (5.1.2)
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.7.0)
+      psych (>= 4.0.0)
     regexp_parser (2.9.2)
+    reline (0.5.10)
+      io-console (~> 0.5)
     rubocop (1.67.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -31,13 +54,16 @@ GEM
     rubocop-ast (1.33.0)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    stringio (3.1.1)
     unicode-display_width (2.6.0)
+    uri (0.13.1)
 
 PLATFORMS
   ruby
   x86_64-linux
 
 DEPENDENCIES
+  debug (~> 1.9, >= 1.9.2)
   electionbuddy-ruby!
   minitest (~> 5.16)
   rake (~> 13.0)

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,8 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "electionbuddy/ruby"
+require "electionbuddy-ruby"
+require "debug"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/electionbuddy-ruby.gemspec
+++ b/electionbuddy-ruby.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "faraday", "~> 2.12"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
This pull request adds the following dependencies to the Electionbuddy Ruby SDK:

1. **Faraday** added to the gemspec:
   - Faraday is now included as a runtime dependency for making HTTP requests.

2. **Debug** added as a development dependency:
   - Debug is included as a development dependency for easier debugging during development.
   - Modified `bin/console` to require Debug.
