### PR TITLE
Retrieve voter list validation results

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,6 @@ Metrics/MethodLength:
 
 Metrics/ClassLength:
   Max: 200
+
+Layout/LineLength:
+  Max: 150

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,4 +15,7 @@ Naming/FileName:
     - 'lib/electionbuddy-ruby.rb'
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 30
+
+Metrics/ClassLength:
+  Max: 200

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added Global configuration for setting the API key using `ElectionBuddy.configure` method
+- Ability to retrieve voter list's validation results
+
+### Changed
+
+- Update README.md with get validtion results usage instructions
+- Update .rubocop.yml with new rules
 
 ### Fixed
 

--- a/lib/election_buddy.rb
+++ b/lib/election_buddy.rb
@@ -12,6 +12,11 @@ require "election_buddy/resources/voter_list_resource"
 require "election_buddy/entities/validation"
 require "election_buddy/error_formatter"
 require "election_buddy/configuration"
+require "election_buddy/entities/validation/result"
+require "election_buddy/entities/validation/line_error"
+require "election_buddy/entities/validation/line_errors"
+require "election_buddy/entities/validation/list_error"
+require "election_buddy/entities/validation/list_errors"
 
 module ElectionBuddy
   class << self

--- a/lib/election_buddy/entities/validation/line_error.rb
+++ b/lib/election_buddy/entities/validation/line_error.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ElectionBuddy
+  class Validation
+    class LineError
+      attr_reader :voter_information_line_id, :errors
+
+      def initialize(line_error)
+        @voter_information_line_id = line_error["voter_information_line_id"]
+        @errors = line_error["errors"]
+      end
+
+      def error_messages
+        @errors.map do |(category, messages)|
+          "#{category}: #{messages.join(", ")}"
+        end
+      end
+    end
+  end
+end

--- a/lib/election_buddy/entities/validation/line_errors.rb
+++ b/lib/election_buddy/entities/validation/line_errors.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ElectionBuddy
+  class Validation
+    class LineErrors
+      include Enumerable
+
+      attr_reader :total, :page, :per_page
+
+      def initialize(response)
+        @line_errors = response["voter_line_errors"]
+        @total = response["meta"]["total"]
+        @page = response["meta"]["page"]
+        @per_page = response["meta"]["per_page"]
+      end
+
+      def total_pages
+        (total.to_f / per_page).ceil
+      end
+
+      def each(&block)
+        collection.each(&block)
+      end
+
+      def empty?
+        collection.empty?
+      end
+
+      def collection
+        @collection ||= @line_errors.map { |line_error| LineError.new(line_error) }
+      end
+    end
+  end
+end

--- a/lib/election_buddy/entities/validation/list_error.rb
+++ b/lib/election_buddy/entities/validation/list_error.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "debug"
+
+module ElectionBuddy
+  class Validation
+    class ListError
+      attr_reader :error, :category, :messages
+
+      def initialize(error)
+        @error = error
+        @category, @messages = error.first
+      end
+
+      def error_message
+        "#{category}: #{messages.join(", ")}"
+      end
+    end
+  end
+end

--- a/lib/election_buddy/entities/validation/list_errors.rb
+++ b/lib/election_buddy/entities/validation/list_errors.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ElectionBuddy
+  class Validation
+    class ListErrors
+      include Enumerable
+
+      attr_reader :total
+
+      def initialize(response)
+        @list_errors = response["voter_list_errors"]
+        @total = response["meta"]["total"]
+      end
+
+      def each(&block)
+        collection.each(&block)
+      end
+
+      def empty?
+        collection.empty?
+      end
+
+      private
+
+      def collection
+        @collection ||= @list_errors
+                        .map { |category, messages| { category => messages } }
+                        .map { |list_error| ListError.new(list_error) }
+      end
+    end
+  end
+end

--- a/lib/election_buddy/entities/validation/result.rb
+++ b/lib/election_buddy/entities/validation/result.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module ElectionBuddy
+  class Validation
+    class UnavailableTotalErrorsCount < ElectionBuddy::Error; end
+    class UnavailableValidStatus < ElectionBuddy::Error; end
+
+    Success = ->(data) { { success?: true, data: data } }
+    Failure = ->(error) { { success?: false, error: error } }
+    private_constant :Success, :Failure
+
+    class Result
+      def initialize(response)
+        @result = process_response(response)
+      end
+
+      def list_errors
+        return [] unless success?
+
+        @list_errors ||= ListErrors.new(@result[:data].dig("results", "voter_list_validations"))
+      end
+
+      def line_errors
+        return [] unless success?
+
+        @line_errors ||= LineErrors.new(@result[:data].dig("results", "voter_lines_validation"))
+      end
+
+      def total_errors_count
+        raise UnavailableTotalErrorsCount, failure_message if failure?
+
+        list_errors.total + line_errors.total
+      end
+
+      def valid?
+        raise UnavailableValidStatus, failure_message if failure?
+
+        total_errors_count.zero?
+      end
+
+      def failure_error
+        return if success?
+
+        ::ElectionBuddy::ErrorFormatter.format(@result[:error])
+      end
+
+      def failure_message
+        return if success?
+
+        "API call has failed - Error: #{failure_error}"
+      end
+
+      private
+
+      def success?
+        @result[:success?]
+      end
+
+      def failure?
+        !success?
+      end
+
+      def process_response(response)
+        if response["error"]
+          Failure.call(response["error"])
+        else
+          Success.call(response)
+        end
+      end
+    end
+  end
+end

--- a/lib/election_buddy/resource.rb
+++ b/lib/election_buddy/resource.rb
@@ -17,7 +17,7 @@ module ElectionBuddy
     private
 
     def handle_response(response)
-      return response.body if response.success? || response.status == 422
+      return response.body if response.success? || [422, 423].include?(response.status)
 
       raise_error(response.status, ErrorFormatter.format(response.body))
     end

--- a/lib/election_buddy/resources/voter_list_resource.rb
+++ b/lib/election_buddy/resources/voter_list_resource.rb
@@ -7,5 +7,12 @@ module ElectionBuddy
 
       Validation.new(response)
     end
+
+    def get_validation_result(identifier, page: 1, per_page: 10)
+      params = { "identifier" => identifier, "page" => page, "per_page" => per_page }
+      response = get_request("/api/v2/votes/voters/validations", params)
+
+      Validation::Result.new(response)
+    end
   end
 end

--- a/test/election_buddy/entities/validation/line_error_test.rb
+++ b/test/election_buddy/entities/validation/line_error_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ElectionBuddy
+  class Validation
+    class LineErrorTest < Minitest::Test
+      def setup
+        line_validation_with_errors = {
+          "voter_line_errors" => [
+            {
+              "voter_information_line_id" => 17_346_137,
+              "errors" => { "email" => ["Email has the wrong format"] }
+            },
+            {
+              "voter_information_line_id" => 17_346_135,
+              "errors" => { "email" => ["Email has the wrong format"] }
+            }
+          ],
+          "meta" => { "total" => 2, "page" => 1, "per_page" => 10 }
+        }
+        @line_error_data = line_validation_with_errors["voter_line_errors"].first
+        @line_error = LineError.new(@line_error_data)
+      end
+
+      def test_initialization
+        assert_equal 17_346_137, @line_error.voter_information_line_id
+        assert_equal({ "email" => ["Email has the wrong format"] }, @line_error.errors)
+      end
+
+      def test_error_messages
+        expected_messages = ["email: Email has the wrong format"]
+        assert_equal expected_messages, @line_error.error_messages
+      end
+    end
+  end
+end

--- a/test/election_buddy/entities/validation/line_errors_test.rb
+++ b/test/election_buddy/entities/validation/line_errors_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ElectionBuddy
+  class Validation
+    class LineErrorsTest < Minitest::Test
+      def setup
+        @line_validation_with_errors = {
+          "voter_line_errors" => [
+            {
+              "voter_information_line_id" => 17_346_137,
+              "errors" => { "email" => ["Email has the wrong format"] }
+            },
+            {
+              "voter_information_line_id" => 17_346_135,
+              "errors" => { "email" => ["Email has the wrong format"] }
+            }
+          ],
+          "meta" => { "total" => 2, "page" => 1, "per_page" => 10 }
+        }
+        @line_errors = LineErrors.new(@line_validation_with_errors)
+      end
+
+      def test_initialization
+        assert_equal 2, @line_errors.total
+        assert_equal 1, @line_errors.page
+        assert_equal 10, @line_errors.per_page
+      end
+
+      def test_total_pages_calculation
+        assert_equal 1, @line_errors.total_pages
+
+        validation_with_more_errors = @line_validation_with_errors.dup
+        validation_with_more_errors["meta"]["total"] = 15
+        line_errors = LineErrors.new(validation_with_more_errors)
+        assert_equal 2, line_errors.total_pages
+      end
+
+      def test_enumerable_implementation
+        assert_kind_of Enumerable, @line_errors
+        assert_equal 2, @line_errors.count
+      end
+
+      def test_collection_contains_line_error_instances
+        @line_errors.each do |error|
+          assert_instance_of LineError, error
+        end
+      end
+
+      def test_collection_maps_data_correctly
+        first_error = @line_errors.first
+        assert_equal 17_346_137, first_error.voter_information_line_id
+        assert_equal({ "email" => ["Email has the wrong format"] }, first_error.errors)
+      end
+    end
+  end
+end

--- a/test/election_buddy/entities/validation/list_error_test.rb
+++ b/test/election_buddy/entities/validation/list_error_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ElectionBuddy
+  class Validation
+    class ListErrorTest < Minitest::Test
+      def setup
+        @error_hash = {
+          "voter_list_overflow" => [
+            "Test elections cannot have more than 5 voters. You have a list of 10 voter(s) and 0 manual key(s) reserved."
+          ]
+        }
+        @list_error = ListError.new(@error_hash)
+      end
+
+      def test_initialization
+        assert_equal "voter_list_overflow", @list_error.category
+        assert_equal ["Test elections cannot have more than 5 voters. You have a list of 10 voter(s) and 0 manual key(s) reserved."],
+                     @list_error.messages
+        assert_equal @error_hash, @list_error.error
+      end
+
+      def test_error_message
+        expected = "voter_list_overflow: Test elections cannot have more than 5 voters. You have a list of 10 voter(s) and 0 manual key(s) reserved."
+        assert_equal expected, @list_error.error_message
+      end
+    end
+  end
+end

--- a/test/election_buddy/entities/validation/list_errors_test.rb
+++ b/test/election_buddy/entities/validation/list_errors_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ElectionBuddy
+  class Validation
+    class ListErrorsTest < Minitest::Test
+      def setup
+        validation_with_errors = {
+          "voter_list_errors" => {
+            "voter_list_overflow" => [
+              "Test elections cannot have more than 5 voters. You have a list of 10 voter(s) and 0 manual key(s) reserved."
+            ]
+          },
+          "meta" => { "total" => 1 }
+        }
+        validation_without_errors = {
+          "voter_list_errors" => {},
+          "meta" => { "total" => 0 }
+        }
+
+        @list_errors = ListErrors.new(validation_with_errors)
+        @empty_list_errors = ListErrors.new(validation_without_errors)
+      end
+
+      def test_total_with_errors
+        assert_equal 1, @list_errors.total
+      end
+
+      def test_total_without_errors
+        assert_equal 0, @empty_list_errors.total
+      end
+
+      def test_empty_list
+        assert @empty_list_errors.empty?
+      end
+
+      def test_each_yields_list_error_instances
+        @list_errors.each do |error|
+          assert_instance_of ListError, error
+          assert_equal "voter_list_overflow", error.category
+          assert_includes error.messages,
+                          "Test elections cannot have more than 5 voters. You have a list of 10 voter(s) and 0 manual key(s) reserved."
+        end
+      end
+    end
+  end
+end

--- a/test/election_buddy/entities/validation/result_test.rb
+++ b/test/election_buddy/entities/validation/result_test.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ElectionBuddy
+  class Validation
+    class ResultTest < Minitest::Test
+      def setup
+        @valid_response = valid_response
+        @list_error_response = list_error_response
+        @line_error_response = line_error_response
+        @error_response = error_response
+      end
+
+      def test_successful_result_state
+        result = Result.new(@valid_response)
+        assert_nil result.failure_error
+        assert_nil result.failure_message
+      end
+
+      def test_failed_result_state
+        result = Result.new(@error_response)
+        assert_equal "Validation: not found", result.failure_error
+        assert_equal "API call has failed - Error: Validation: not found", result.failure_message
+      end
+
+      def test_valid_result
+        result = Result.new(@valid_response)
+        assert result.valid?
+        assert_equal 0, result.total_errors_count
+      end
+
+      def test_list_validation_errors
+        result = Result.new(@list_error_response)
+        refute result.valid?
+        assert_equal 1, result.total_errors_count
+      end
+
+      def test_line_validation_errors
+        result = Result.new(@line_error_response)
+        refute result.valid?
+        assert_equal 2, result.total_errors_count
+      end
+
+      def test_list_errors_returns_proper_instance
+        result = Result.new(@list_error_response)
+        list_errors = result.list_errors
+        assert_instance_of ListErrors, list_errors
+      end
+
+      def test_line_errors_returns_proper_instance
+        result = Result.new(@line_error_response)
+        line_errors = result.line_errors
+        assert_instance_of LineErrors, line_errors
+      end
+
+      def test_list_errors_returns_empty_array_on_failure
+        result = Result.new(@error_response)
+        assert_empty result.list_errors
+      end
+
+      def test_line_errors_returns_empty_array_on_failure
+        result = Result.new(@error_response)
+        assert_empty result.line_errors
+      end
+
+      def test_total_errors_count_raises_error_on_failure
+        result = Result.new(@error_response)
+        assert_raises(UnavailableTotalErrorsCount) { result.total_errors_count }
+      end
+
+      def test_valid_status_raises_error_on_failure
+        result = Result.new(@error_response)
+        assert_raises(UnavailableValidStatus) { result.valid? }
+      end
+
+      private
+
+      def valid_response
+        {
+          "results" => {
+            "vote_id" => 58_812,
+            "validation_id" => 929,
+            "identifier" => "90dd086d-d4a3-4f02-9de4-221880355052",
+            "voter_list_validations" => valid_list_validation,
+            "voter_lines_validation" => valid_line_validation
+          }
+        }
+      end
+
+      def list_error_response
+        {
+          "results" => {
+            "vote_id" => 58_777,
+            "validation_id" => 935,
+            "identifier" => "ba1716d5-a5f4-4b8f-ad0b-5f6e868caf51",
+            "voter_list_validations" => list_validation_with_errors,
+            "voter_lines_validation" => valid_line_validation
+          }
+        }
+      end
+
+      def line_error_response
+        {
+          "results" => {
+            "vote_id" => 58_787,
+            "validation_id" => 937,
+            "identifier" => "dfe4c244-5b92-4158-85a8-696025480d30",
+            "voter_list_validations" => valid_list_validation,
+            "voter_lines_validation" => line_validation_with_errors
+          }
+        }
+      end
+
+      def error_response
+        {
+          "error" => {
+            "validation" => "not found"
+          }
+        }
+      end
+
+      def valid_list_validation
+        {
+          "voter_list_errors" => {},
+          "meta" => { "total" => 0 }
+        }
+      end
+
+      def valid_line_validation
+        {
+          "voter_line_errors" => [],
+          "meta" => { "total" => 0, "page" => 1, "per_page" => 10 }
+        }
+      end
+
+      def list_validation_with_errors
+        {
+          "voter_list_errors" => {
+            "voter_list_overflow" => [
+              "Test elections cannot have more than 5 voters. You have a list of 10 voter(s) and 0 manual key(s) reserved."
+            ]
+          },
+          "meta" => { "total" => 1 }
+        }
+      end
+
+      def line_validation_with_errors
+        {
+          "voter_line_errors" => [
+            {
+              "voter_information_line_id" => 17_346_137,
+              "errors" => { "email" => ["Email has the wrong format"] }
+            },
+            {
+              "voter_information_line_id" => 17_346_135,
+              "errors" => { "email" => ["Email has the wrong format"] }
+            }
+          ],
+          "meta" => { "total" => 2, "page" => 1, "per_page" => 10 }
+        }
+      end
+    end
+  end
+end

--- a/test/election_buddy/resources/voter_list_resource_test.rb
+++ b/test/election_buddy/resources/voter_list_resource_test.rb
@@ -36,5 +36,72 @@ module ElectionBuddy
       refute validation.done?
       assert_equal "Vote: not found", validation.error
     end
+
+    def test_get_validation_result_success
+      @stubs.get("/api/v2/votes/voters/validations?identifier=test-id&page=1&per_page=10") do
+        [200, { "Content-Type" => "application/json" },
+         { results: {
+           vote_id: 58_812,
+           validation_id: 929,
+           identifier: "test-id",
+           voter_list_validations: {
+             voter_list_errors: {},
+             meta: { total: 0 }
+           },
+           voter_lines_validation: {
+             voter_line_errors: [],
+             meta: { total: 0, page: 1, per_page: 10 }
+           }
+         } }.to_json]
+      end
+
+      result = @resource.get_validation_result("test-id")
+
+      assert result.valid?
+      assert_equal 0, result.total_errors_count
+      assert_empty result.list_errors
+      assert_empty result.line_errors
+    end
+
+    def test_get_validation_result_with_errors
+      @stubs.get("/api/v2/votes/voters/validations?identifier=test-id&page=1&per_page=10") do
+        [200, { "Content-Type" => "application/json" },
+         { results: {
+           vote_id: 58_777,
+           validation_id: 935,
+           identifier: "test-id",
+           voter_list_validations: {
+             voter_list_errors: {
+               voter_list_overflow: ["Test elections cannot have more than 5 voters"]
+             },
+             meta: { total: 1 }
+           },
+           voter_lines_validation: {
+             voter_line_errors: [],
+             meta: { total: 0, page: 1, per_page: 10 }
+           }
+         } }.to_json]
+      end
+
+      result = @resource.get_validation_result("test-id")
+
+      refute result.valid?
+      assert_equal 1, result.total_errors_count
+      refute_empty result.list_errors
+    end
+
+    def test_get_validation_result_failure
+      @stubs.get("/api/v2/votes/voters/validations?identifier=invalid-id&page=1&per_page=10") do
+        [422, { "Content-Type" => "application/json" },
+         { error: { validation: "not found" } }.to_json]
+      end
+
+      result = @resource.get_validation_result("invalid-id")
+
+      assert_equal "Validation: not found", result.failure_error
+      assert_equal "API call has failed - Error: Validation: not found", result.failure_message
+      assert_raises(::ElectionBuddy::Validation::UnavailableTotalErrorsCount) { result.total_errors_count }
+      assert_raises(::ElectionBuddy::Validation::UnavailableValidStatus) { result.valid? }
+    end
   end
 end


### PR DESCRIPTION
This pull request adds the ability to retrieve voter list validation results. Specifically, methods were implemented to:

- Obtain the validation result using a validation identifier.
- Check if the voter list is valid or not.
- Retrieve list-level errors, which affect the entire voter list (e.g., missing required columns).
- Retrieve line-level errors, which affect specific lines in the voter list (e.g., invalid email format).
- Paginate line-level errors, allowing specification of the page number and the number of errors per page.